### PR TITLE
Raised PHP7 cphalcon branch to the official final LTS 3.0.x

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -11,5 +11,5 @@ build:
         override:
             - composer install --prefer-source --no-interaction
         after: 
-            - bin/install-phalcon.sh 2.1.x
+            - bin/install-phalcon.sh 3.0.x
             - php -r "echo \Phalcon\Version::get();"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 
 before_install:
   - composer install --prefer-source --no-interaction
-  - bin/install-phalcon.sh 2.1.x
+  - bin/install-phalcon.sh 3.0.x
 
 script:
   - php -r "echo \Phalcon\Version::get();"

--- a/shippable.yml
+++ b/shippable.yml
@@ -12,6 +12,6 @@ build:
   ci:
     - php --version
     - composer install --prefer-source --no-interaction
-    - bin/install-phalcon.sh 2.1.x
+    - bin/install-phalcon.sh 3.0.x
     - php -r "echo \Phalcon\Version::get();"
     - vendor/bin/phpunit


### PR DESCRIPTION
Phalcon 3.0.0 final (LTS) released
https://blog.phalconphp.com/1

2.1 is dead, all hail 3.0
As mentioned above, 2.1 will not be fully backwards compatible. As a result, we are changing the version number to 3.0.
