### PR TITLE
Only use Zephir for php7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following table outlines general compability of Phalcon inside various CI en
 | PHP CI Version | Phalcon Version(s) | CI Environment |
 |:---------------|:-------------------|:---------------|
 | 5.3            | ✖   (Not supported)            | - |
-| 5.4            | ✔   `master`, `2.0.x`, `3.0.x` | ✔ CircleCI, Travis CI, Scrutinizer, Codeship, Shippable |
+| 5.4            | ✖   (Not supported)            | - |
 | 5.5            | ✔   `master`, `2.0.x`, `3.0.x` | ✔ CircleCI, Travis CI, Scrutinizer, Codeship, Shippable |
 | 5.6            | ✔   `master`, `2.0.x`, `3.0.x` | ✔ CircleCI, Travis CI, Scrutinizer, Codeship, Shippable |
 | 7.0            | ✔   `3.0.x`                    | ✔ CircleCI, Travis CI, Scrutinizer, Codeship, Shippable |
@@ -111,7 +111,6 @@ test:
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/bin/install-phalcon.sh
+++ b/bin/install-phalcon.sh
@@ -134,14 +134,11 @@ cd ${PHALCON_DIR}/ext
 # Build Phalcon.
 echo "Building Phalcon for ${PHP_VER} ..."
 
-# Temporarilly using zephir for all builds. Once https://github.com/phalcon/cphalcon/issues/11961 
-# gets fixed we can revert to only PHP7 using zephir.
-
 # Various CI Providers including Codeship, CircleCI have issues when compiling Zephir 
 # and require higher PHP limits even though the container has adaquete memory.
 echo "memory_limit=-1" > ${PHP_CONF_DIR}/phalcon-ci-installer.ini
 
-# if [[ $PHP_VER == 7* ]]; then
+if [[ $PHP_VER == 7* ]]; then
 
     # Note that Codeship has potential to set only the local PHP environment since this
     # option is how the environment is setup. Documentation references using `phpenv local ...`
@@ -154,11 +151,8 @@ echo "memory_limit=-1" > ${PHP_CONF_DIR}/phalcon-ci-installer.ini
     
     # Compile
     cd ${PHALCON_DIR}
-    if [[ $PHP_VER == 7* ]]; then
-        ${CI_APP_DIR}/vendor/phalcon/zephir/bin/zephir compile --backend=ZendEngine3
-    else 
-        ${CI_APP_DIR}/vendor/phalcon/zephir/bin/zephir compile
-    fi
+
+    ${CI_APP_DIR}/vendor/phalcon/zephir/bin/zephir compile --backend=ZendEngine3
         
     # Install
     cd ${PHALCON_DIR}/ext
@@ -168,10 +162,10 @@ echo "memory_limit=-1" > ${PHP_CONF_DIR}/phalcon-ci-installer.ini
     ./configure --enable-phalcon
     make --silent -j4
     make --silent install
-# else
-#     cd ${PHALCON_DIR}/build
-#     ./install
-# fi
+else
+    cd ${PHALCON_DIR}/build
+    ./install
+fi
 
 # Ensure extension exists
 echo "extension=phalcon.so" > ${PHP_CONF_DIR}/phalcon.ini


### PR DESCRIPTION
https://github.com/phalcon/cphalcon/issues/11961 Was fixed and the script can now compile older PHP versions without Zephir.